### PR TITLE
Fixed an address for checkOpType in rgloader-hvxpeekpoke,s

### DIFF
--- a/Patches/RGL/17559-dev/RGLoader-HvxPeekPoke.S
+++ b/Patches/RGL/17559-dev/RGLoader-HvxPeekPoke.S
@@ -29,7 +29,7 @@ checkOpType:
 	cmplwi    cr6, %r4, 4
 	bgt       cr6, doMemCpy
 	beq       cr6, hvxExecuteCode
-	li        %r5, 0x154C
+	li        %r5, 0x15F0
 	lis       %r6, 0x3880 #;//0x38800007
 	cmplwi    cr6, %r4, 2
 	bne       cr6, loc_B5C0


### PR DESCRIPTION
the rgloader team got this address for checkOpType wrong. it should be 0x15F0.

this fix is confirmed working and enables:

HvxGetVersions(0x72627472, 3) should enable memory protection, HvxGetVersions(0x72627472, 2) should disable it

thanks emma for the fix